### PR TITLE
Fix loading state issue when editing clients

### DIFF
--- a/frontend/src/app/components/cliente-cad.component.html
+++ b/frontend/src/app/components/cliente-cad.component.html
@@ -1,9 +1,12 @@
 <div>
-    <form [formGroup]="form" (ngSubmit)="onSubmit()" (onDataLoaded)="onDataLoaded($event)">          
+    <div *ngIf="loading" class="text-center">
+        <p>Loading client data...</p>
+    </div>
+    <form [formGroup]="form" (ngSubmit)="onSubmit()" (onDataLoaded)="onDataLoaded($event)" *ngIf="!loading">          
 
         <div class="form-group col-md-6">
             <label for="code">Code</label>
-            <input type="number" id="code" class="form-control" placeholder="Code" formControlName="code" required />
+            <input type="number" id="code" class="form-control" placeholder="Code" formControlName="code" [disabled]="submited" required />
             <small *ngIf="submited && form.get('code')?.errors?.required" 
                 class="form-text text-muted">*Required field
             </small>
@@ -11,7 +14,7 @@
 
         <div class="form-group col-md-6">
             <label for="name">Name</label>
-            <input type="text" id="name" class="form-control" placeholder="Code" formControlName="name" required />
+            <input type="text" id="name" class="form-control" placeholder="Name" formControlName="name" [disabled]="submited" required />
             <small *ngIf="submited && form.get('name')?.errors?.required" 
                 class="form-text text-muted">*Required field
             </small>
@@ -19,7 +22,7 @@
 
         <div class="form-group col-md-6">
             <label for="address">Address</label>
-            <input type="text" id="address" class="form-control" placeholder="Address" formControlName="address" required />
+            <input type="text" id="address" class="form-control" placeholder="Address" formControlName="address" [disabled]="submited" required />
             <small *ngIf="submited && form.get('address')?.errors?.required" 
                 class="form-text text-muted">*Required field
             </small>
@@ -27,7 +30,7 @@
 
         <div class="form-group col-md-6">
             <label for="address">Telephone</label>
-            <input type="text" id="telephone" class="form-control" placeholder="Telephone" formControlName="telephone" required />
+            <input type="text" id="telephone" class="form-control" placeholder="Telephone" formControlName="telephone" [disabled]="submited" required />
             <small *ngIf="submited && form.get('telephone')?.errors?.required" 
                 class="form-text text-muted">*Required field
             </small>
@@ -35,7 +38,7 @@
 
         <div class="form-group col-md-6">
             <label for="status">Status</label>
-            <select id="status" class="form-control" formControlName="status" required>
+            <select id="status" class="form-control" formControlName="status" [disabled]="submited" required>
                 <option value="" selected>(selecione)</option>
                 <option value="active">active</option>
                 <option value="deleted">deleted</option>
@@ -48,13 +51,16 @@
         
         <div class="form-group col-md-6">
             <label for="birthDate">Birth Date</label>
-            <input type="text" id="birthDate" class="form-control" placeholder="Birth Date" formControlName="birthDate" required />
+            <input type="text" id="birthDate" class="form-control" placeholder="Birth Date" formControlName="birthDate" [disabled]="submited" required />
             <small *ngIf="submited && form.get('birthDate')?.errors?.required" 
                 class="form-text text-muted">*Required field
             </small>
         </div>        
 
-        <button class="btn btn-primary" type="submit">Save</button>
+        <button class="btn btn-primary" type="submit" [disabled]="submited">
+            <span *ngIf="!submited">Save</span>
+            <span *ngIf="submited">Saving...</span>
+        </button>
     </form>
 
     <div *ngIf="message">

--- a/frontend/src/app/components/cliente-cad.component.ts
+++ b/frontend/src/app/components/cliente-cad.component.ts
@@ -17,6 +17,7 @@ export class ClienteCadComponent implements OnInit, AfterViewInit {
   submited = false;
   message = null;
   error = false;
+  loading = false;
   
   form = this.initForm();
 
@@ -42,13 +43,16 @@ export class ClienteCadComponent implements OnInit, AfterViewInit {
 	ngAfterViewInit() {
 
     if(this.id) {
+      this.loading = true;
       this.clienteService.getById(this.id)
       .subscribe(
         data => {
           this.form = this.initForm(data);
+          this.loading = false;
         },
         error =>  {
           this.message = error;
+          this.loading = false;
         }
       );
     }
@@ -77,6 +81,7 @@ export class ClienteCadComponent implements OnInit, AfterViewInit {
       },
       error =>  {
         this.message = error;
+        this.submited = false;
       }
     );
   }
@@ -91,6 +96,7 @@ export class ClienteCadComponent implements OnInit, AfterViewInit {
         },
         error =>  {
           this.message = error;
+          this.submited = false;
         }
       );
   }


### PR DESCRIPTION
Fixes #2

## Summary
- Add proper loading state management to client edit form
- Show loading indicator while fetching client data
- Disable form controls during submission
- Display "Saving..." text on button during save
- Reset submitted flag on errors to allow retry

## Changes
- Added `loading` flag to track data fetch state
- Hide form and show loading message while fetching data
- Disable all form inputs during submission
- Show dynamic button text based on submission state
- Reset `submitted` flag on errors

Generated with [Claude Code](https://claude.ai/code)